### PR TITLE
Fix for Uberlauncher users on Titans

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # PA Mod Manager (electron edition)
 
+## Privacy Notice
+
+PAMM downloads mods and icons from external sources. Your IP could be collected by any of those servers. You are using PAMM at your own risk!
+
+## History
+
 Original Windows version : https://forums.uberent.com/threads/rel-pa-mod-manager-v4-0-3.50726/
 
 Original Linux and Mac OS X version : https://forums.uberent.com/threads/rel-raevns-pa-mod-manager-for-linux-and-mac-os-x-version-4-0-2.50958/

--- a/app/assets/js/pa.js
+++ b/app/assets/js/pa.js
@@ -114,7 +114,7 @@ function createStreamObject(paPath, osxapp) {
 
 	var stockmodspath = path.join(resourcesPath, '/media/stockmods');
 
-	var titans = paPath.indexOf('Planetary Annihilation Titans') != -1;
+	var titans = fs.existsSync(path.join(paPath,'media/pa_ex1'));
 
 	var steam = paPath.toLowerCase().indexOf('steamapps') != -1;
 	var uberLauncher = !steam;

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pamm-atom",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Mod manager for Planetary Annihilation Titans & Classic",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
They were unable to download titans only mods.